### PR TITLE
Updated chromedriver_powershell_version to access stdout property

### DIFF
--- a/libraries/default.rb
+++ b/libraries/default.rb
@@ -1,7 +1,7 @@
 # Fixes drivers not copied to /selenium/drivers/ folders on Windows 7
 def chromedriver_powershell_version
   out = shell_out!('powershell.exe $host.version.major')
-  out.to_i
+  out.stdout.to_i
 rescue # powershell not installed
   -1
 end


### PR DESCRIPTION
I've been getting the following error when trying to run the selenium grid node recipe on some windows 2008R2 VMs. 

```
 ================================================================================
 Error executing action `unzip` on resource 'windows_zipfile[C:/chromedriver/chromedriver_win32-2.23]'
 ================================================================================
 
 Zip::DestinationFileExistsError
 -------------------------------
 Destination 'C:/chromedriver/chromedriver_win32-2.23/chromedriver.exe' already exists
 
 Resource Declaration:
 ---------------------
 # In c:/chef/cookbooks/chef-selenium-grid/config/local-mode-cache/cache/cookbooks/chromedriver/recipes/default.rb
 
  48:   windows_zipfile driver_path do
  49:     source cache_path
  50:     action :nothing
  51:     not_if { chromedriver_powershell_version >= 3 }
  52:   end
  53: end
 
 Compiled Resource:
 ------------------
 # Declared in c:/chef/cookbooks/chef-selenium-grid/config/local-mode-cache/cache/cookbooks/chromedriver/recipes/default.rb:48:in `from_file'
 
 windows_zipfile("C:/chromedriver/chromedriver_win32-2.23") do
   action [:nothing]
   retries 0
   retry_delay 2
   default_guard_interpreter :default
   declared_type :windows_zipfile
   cookbook_name "chromedriver"
   recipe_name "default"
   source "c:\\chef\\cookbooks\\chef-selenium-grid\\config\\local-mode-cache\\cache/chromedriver_win32-2.23.zip"
   path "C:/chromedriver/chromedriver_win32-2.23"
   not_if { #code block }
 end
 
 Platform:
 ---------
 x64-mingw32
 
 INFO: Running queued delayed notifications before re-raising exception
 ERROR: Running exception handlers
 ERROR: Exception handlers complete
 FATAL: Stacktrace dumped to c:/chef/cookbooks/chef-selenium-grid/config/local-mode-cache/cache/chef-stacktrace.out
 FATAL: Please provide the contents of the stacktrace.out file if you file a bug report
 FATAL: Zip::DestinationFileExistsError: windows_zipfile[C:/chromedriver/chromedriver_win32-2.23] (chromedriver::default line 48) had an error: Zip::DestinationFileExistsError: Destination 'C:/chromedriver/chromedriver_win32-2.23/chromedriver.exe' already exists
```

So, I was looking into it and was very sure that my Powershell version is greater than '3', and I ran `$host.version.major` which returns `4` on my system. I then started up chef-shell and tried to run the `chromedriver_powershell_version` library and found that `out` is an object returned from shellout with no method `to_i`. I think the correct fix is to access the stdout property on that object and cast it to an integer. I made this fix in my branch, and the selenium grid node recipe seems to be running fine :)