### PR TITLE
Make sure that the latest version can be retrieved behind proxy

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'dennis.hoer@gmail.com'
 license 'MIT'
 description 'Selenium WebDriver for Chrome'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.2.2'
+version '1.2.3'
 
 supports 'centos'
 supports 'debian'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -13,11 +13,7 @@ end
 
 version = node['chromedriver']['version']
 if version == 'LATEST_RELEASE'
-  uri = URI("#{node['chromedriver']['url']}/#{version}")
-  res = Net::HTTP.start(uri.host, use_ssl: true, verify_mode: OpenSSL::SSL::VERIFY_NONE) do |http|
-    http.get uri.request_uri
-  end
-  version = res.body.strip
+  version = Chef::HTTP.new(node['chromedriver']['url']).get('/LATEST_RELEASE').strip
 end
 
 name = "chromedriver_#{os}#{bit}-#{version}"

--- a/spec/unit/default_spec.rb
+++ b/spec/unit/default_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-VERSION = '2.23'.freeze
+VERSION = '2.24'.freeze
 
 describe 'chromedriver::default' do
   context 'windows' do


### PR DESCRIPTION
I had some problems with retrieving the latest version while being
behind a proxy. I've tried all sorts of options with ENV['http_proxy']
but was unable to make this work.
This seemed like the most logical solution, to use Chef classes
themselves.
